### PR TITLE
citeonline em ingles

### DIFF
--- a/ita.cls
+++ b/ita.cls
@@ -194,7 +194,11 @@
 
 %==============================================================================
 %%% ABNTeX ...
-\RequirePackage[alf,abnt-emphasize=bf,abnt-etal-cite=2,abnt-etal-list=0,abnt-etal-text=it]{abntcite}
+\if@eng
+  \RequirePackage[alf,abnt-emphasize=bf,abnt-etal-cite=2,abnt-etal-list=0,abnt-etal-text=it,abnt-and-type=\&]{abntcite}
+\else
+  \RequirePackage[alf,abnt-emphasize=bf,abnt-etal-cite=2,abnt-etal-list=0,abnt-etal-text=it]{abntcite}  
+\fi
 %\RequirePackage{natbib}
 
 %==============================================================================


### PR DESCRIPTION
Pequena modificação no arquivo ita.cls para que as citações feitas com o comando \citeonline do pacote abntcite apareçam com o símbolo "&" ao invés de "e" no caso em que há dois autores e o trabalho esteja em inglês.

Ex: Fulano e Cicrano (2024) -> Fulano & Cicrano (2024). 